### PR TITLE
Find ALL files named *.old, not just *.php.old

### DIFF
--- a/src/Finder/OldToNewFilesFinder.php
+++ b/src/Finder/OldToNewFilesFinder.php
@@ -62,7 +62,7 @@ final class OldToNewFilesFinder
             // excluded built files
             ->exclude('composer/')
             ->exclude('ocramius/')
-            ->name('*.php.old');
+            ->name('*.old'); 
 
         return $this->finderSanitizer->sanitize($finder);
     }


### PR DESCRIPTION
There are other files in the vendor folder, they are not only .php files there, and sometimes these files need patching too. For example *.js or *.css files. Since the behavior of only finding *.php.old files is not mentioned in the documentation, nor implied in the package's name ("vendor-patches"), nor particularly useful for anything else than a speed optimization (and probably not even that), I removed this artificial limitation.