### PR TITLE
Update README with composer-patches recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Generate vendor patches for packages with single command.
 
 ```bash
 composer require symplify/vendor-patches --dev
+
+# If you are applying patches to production, be sure to also explicitly add cweagans/composer-patches.
+composer require cweagans/composer-patches
 ```
 
 ## Usage


### PR DESCRIPTION
By specifying this, we ensure that users can apply patches to production. vendor-patches is added as `--dev`, so it won't work if the user forgets to add it explicitly.

I mistakenly considered myself a non-beginner, but I fell into this trap once when adding composer-patches to a new project 😇 